### PR TITLE
Fixed loader name misspelled

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ header hack.
 
 ### Webpack usage
 
-To use fetch with webpack, you will need `import-loader`, `export-loader`, `es6-promise` and require it this way:
+To use fetch with webpack, you will need `imports-loader`, `exports-loader`, `es6-promise` and require it this way:
 
 ```javascript
 var fetch = require('imports?self=>{},es6p=es6-promise,Promise=>es6p.Promise!exports?self.fetch!whatwg-fetch');


### PR DESCRIPTION
Loader ```import-loader || export-loader' is not in the npm registry ```, name must be ```imports-loader exports-loader ```.